### PR TITLE
Switch from `runc` to `crun` for x86_64 and aarch64

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
     - 0002-relative-paths-for-system-config-and-binaries.patch  # [not win]
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
@@ -48,8 +48,8 @@ requirements:
     - conmon >=2.0.30            # [linux]
     - containers-common          # [not win]
     - cni-plugins                # [linux]
-    # TODO: switch to crun?
-    - runc                       # [linux]
+    - crun                       # [linux and (x86_64 or aarch64)]
+    - runc                       # [linux and ppc64le]
     - slirp4netns                # [linux]
     - netavark                   # [linux]
 


### PR DESCRIPTION
This pull request makes minor updates to the `recipe/meta.yaml` file, primarily adjusting the build number and refining dependency requirements for different Linux architectures.

Dependency requirement updates:

* Switched the container runtime dependency from `runc` to `crun` for Linux systems on `x86_64` and `aarch64`, while retaining `runc` only for `ppc64le` Linux systems.

---

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
